### PR TITLE
default role for authenticated users

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ $amp_allowed_plugin_pages = array(
 ```
 Explore the code to see how to set `$amp_role_capabilities` and `$amp_anon_capabilities`. These are set to defaults in the `amp_env_check()` function.
 
+You can also assign a default role to all logged-in users that have no explicit role:
+```
+$amp_default_role = "Editor";
+```
+
+
 #### NOTE:
 This is a fork of nicwaller's [Authmgr](https://github.com/nicwaller/yourls-authmgr-plugin) merged with Ian barber's[Seperate User's](https://github.com/joshp23/Yourls-Separate-Users) plugin. Both code bases underwent heavy rewrites, and have been extensively updated and tightly integrated here, resulting in a lean and highly functional user authorization management environment.
 

--- a/authMgrPlus/plugin.php
+++ b/authMgrPlus/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: Auth Manager Plus
 Plugin URI:  https://github.com/joshp23/YOURLS-AuthMgrPlus
 Description: Role Based Access Controlls with seperated user data for authenticated users
-Version:     2.1.2
+Version:     2.2.0
 Author:      Josh Panter, nicwaller, Ian Barber <ian.barber@gmail.com>
 Author URI:  https://unfettered.net
 */

--- a/authMgrPlus/plugin.php
+++ b/authMgrPlus/plugin.php
@@ -219,6 +219,7 @@ function amp_have_capability( $capability ) {
 	global $amp_anon_capabilities;
 	global $amp_role_capabilities;
 	global $amp_admin_ipranges;
+	global $amp_default_role;
 
 	// Make sure the environment has been setup
 	amp_env_check();
@@ -252,6 +253,12 @@ function amp_have_capability( $capability ) {
 			if( $return ) 
 				break;
 		}
+	}
+	if( !$return ) {
+	    if ( isset( $amp_default_role )  && in_array ($amp_default_role, array_keys( $amp_role_capabilities ) ) ) {
+		$default_caps = $amp_role_capabilities [ $amp_default_role ];
+		$return =  in_array( $capability, $default_caps );
+	    }
 	}
 	return $return;
 }


### PR DESCRIPTION
when dealing with more than a handful users that are managed elsewhere (e.g. in LDAP), it is often impractical to assign a role to each of them.
instead it would be nice to be able to define a fallback role.

this PR implements just that.

if a user is found in the `$amp_role_assignment` array, this role is used.
if not, the `$amp_default_role` is used instead (only for authenticated users, of course).

E.g.

~~~php
$amp_role_assignment = array(
  'administrator' => array(
    'my_user_name',
  ),
  'editor' => array(
    'some_friend'
  ),
  'contributor' => array(
    'trainee', // we don't trust them yet
  ),
);
$amp_default_role = 'Editor';
~~~

This will make `my_user_name` an *Administrator*, and everybody else an *Editor*, except for `trainee` who is only a *Contributor*.